### PR TITLE
Docs & TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,20 @@
 language: crystal
+
 crystal:
   - latest
   - nightly
+
 script:
   - crystal spec
   - crystal run examples/test.cr
   - crystal run examples/test2.cr
+  - crystal docs
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  project_name: dialogflow-crystal
+  on:
+    branch: master
+  local_dir: docs


### PR DESCRIPTION
Hey, i have added the TravisCI option to automatically deploy the page of the documentation.

**Note:** You need to generate a [Personal Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) and add it to the env (`GITHUB_TOKEN`) in the Travis config