### PR TITLE
Bump version to 0.4.1 to tag it as shards expect

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: faker
-version: 0.2.0
+version: 0.4.1
 
 authors:
   - Aşkın Gedik <askn@bil.omu.edu.tr>

--- a/src/faker/version.cr
+++ b/src/faker/version.cr
@@ -1,3 +1,3 @@
 module Faker
-  VERSION = "0.3.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
Right now shards complains about improper `version`:

```
Shard "faker" version (0.2.0) doesn't match tag version (0.4.0)
```

This is because tag `v0.4.0` has mismatching version in `shards.yml` and `src/faker/version.cr`

After this is merged tag `v0.4.1` should be released to fix further incompatibilities with newer `shards` command.