### PR TITLE
Support Crystal 1.0 version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,9 @@
 name: faker
-version: 0.5.0
+version: 0.6.0
 
 authors:
   - Aşkın Gedik <askn@bil.omu.edu.tr>
 
 license: MIT
+
+crystal: "~> 1.0, >= 1.0.0"


### PR DESCRIPTION
Try to fix this:

```
Unable to satisfy the following requirements:

- `crystal (< 1.0.0)` required by `faker 0.5.0`
```